### PR TITLE
Add team member contributions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,30 @@ Enter the names of up to four roommates and specify the rent and grocery totals.
 
 The repository includes a sample `data/database` file for convenience. You can delete it and run the `init-db` command to start fresh.
 
+
+## Team Contributions
+
+- **Edward Clark (Project Manager & Backend Developer)**  
+  Led development and planning. Built and tested all backend Flask routes including `/add_expense`, `/get_expenses`, and `/get_balances`. Integrated form inputs with SQLite, connected frontend to backend, managed GitHub repository, and ensured project completion.
+
+- **Emma (Frontend Developer)**  
+  Built the HTML form layout and JavaScript functions for validating user input and submitting expenses. Implemented the initial structure of the Add Bill and View Debts functionality and styled the user interface.
+
+- **Matt (Backend Developer)**  
+  Assisted with backend database logic and route handling.
+
+- **Zane (Data Handler)**  
+  Managed JSON data or database layer.
+
+## Sample output
+
+The `/get_expenses` endpoint returns JSON similar to the following:
+
+```json
+[
+    {"id": 1, "description": "Rent", "amount": 999.0},
+    {"id": 2, "description": "Groceries", "amount": 999.0},
+    {"id": 3, "description": "Rent", "amount": 843.0},
+    {"id": 4, "description": "Groceries", "amount": 838.0}
+]
+```


### PR DESCRIPTION
## Summary
- add section describing each team member's contribution
- document example JSON from `/get_expenses` API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688990b92c1c8321b22f08d36b28c934